### PR TITLE
TSV-760: Replace smserver with wiremock.

### DIFF
--- a/app/uk/gov/hmrc/personaldetailsvalidation/matching/MatchingConnector.scala
+++ b/app/uk/gov/hmrc/personaldetailsvalidation/matching/MatchingConnector.scala
@@ -20,7 +20,7 @@ import javax.inject.{Inject, Singleton}
 
 import play.api.http.Status._
 import play.api.libs.json.{JsObject, Json}
-import uk.gov.hmrc.http.{HeaderCarrier, HttpException, HttpReads, HttpResponse}
+import uk.gov.hmrc.http._
 import uk.gov.hmrc.personaldetailsvalidation.matching.MatchingConnector.MatchResult
 import uk.gov.hmrc.personaldetailsvalidation.matching.MatchingConnector.MatchResult.{MatchFailed, MatchSuccessful}
 import uk.gov.hmrc.personaldetailsvalidation.model.PersonalDetails
@@ -46,10 +46,7 @@ class MatchingConnector @Inject()(private val httpClient: HttpClient,
     override def read(method: String, url: String, response: HttpResponse): MatchResult = response.status match {
       case OK => MatchSuccessful
       case UNAUTHORIZED => MatchFailed
-      case other => throw new HttpException(
-        message = s"Unexpected response from $method $url with status: '$other' and body: ${response.body}",
-        responseCode = other
-      )
+      case other => throw new BadGatewayException(s"Unexpected response from $method $url with status: '$other' and body: ${response.body}")
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
 import TestPhases.oneForkedJvmPerTest
 import uk.gov.hmrc.DefaultBuildSettings.{addTestReportOption, defaultSettings, scalaSettings}
-import uk.gov.hmrc.ExternalService
-import uk.gov.hmrc.ServiceManagerPlugin.Keys._
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
 val appName = "personal-details-validation"
@@ -11,14 +9,6 @@ lazy val playSettings: Seq[Setting[_]] = Seq(
     "uk.gov.hmrc.personaldetailsvalidation.model.ValidationId",
     "uk.gov.hmrc.play.pathbinders.PathBinders._"
   )
-)
-
-lazy val externalServices = List(
-  ExternalService("AUTHENTICATOR"),
-  ExternalService("CITIZEN_DETAILS"),
-  ExternalService("DATASTREAM"),
-  ExternalService("MATCH"),
-  ExternalService("MATCHING_STUB")
 )
 
 lazy val microservice = Project(appName, file("."))
@@ -35,8 +25,6 @@ lazy val microservice = Project(appName, file("."))
   )
   .configs(IntegrationTest)
   .settings(inConfig(IntegrationTest)(Defaults.itSettings): _*)
-  .settings(ServiceManagerPlugin.serviceManagerSettings)
-  .settings(itDependenciesList := externalServices)
   .settings(
     Keys.fork in IntegrationTest := false,
     unmanagedSourceDirectories in IntegrationTest := (baseDirectory in IntegrationTest)(base => Seq(base / "it")).value,

--- a/it/uk/gov/hmrc/support/stubs/AuthenticatorStub.scala
+++ b/it/uk/gov/hmrc/support/stubs/AuthenticatorStub.scala
@@ -1,0 +1,43 @@
+package uk.gov.hmrc.support.stubs
+
+import com.github.tomakehurst.wiremock.client.MappingBuilder
+import com.github.tomakehurst.wiremock.client.WireMock._
+import play.api.http.Status._
+
+object AuthenticatorStub {
+
+  private val path: String = "/authenticator/match"
+
+  def expecting(personalDetailsJson: String) = new {
+
+    private val mappingBuilder = post(urlEqualTo(path)).withRequestBody(equalToJson(personalDetailsJson, true, false))
+
+    def respondWithOK(): Unit = {
+      stubFor(
+        mappingBuilder.willReturn(
+            aResponse()
+              .withStatus(OK)
+              .withBody(
+                """{
+                  | "firstName":"Jim",
+                  | "lastName":"Ferguson",
+                  | "dateOfBirth":"1948-04-23",
+                  | "nino":"AA000003D",
+                  | "saUtr":"1097133333"
+                  |}
+                  | """.stripMargin)
+          )
+      )
+    }
+
+    def respondWith(status: Int): Unit = {
+      stubFor(
+        mappingBuilder.willReturn(
+          aResponse().withStatus(status)
+        )
+      )
+    }
+  }
+
+
+}

--- a/it/uk/gov/hmrc/support/wiremock/WiremockHelper.scala
+++ b/it/uk/gov/hmrc/support/wiremock/WiremockHelper.scala
@@ -1,0 +1,27 @@
+package uk.gov.hmrc.support.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+
+object WiremockConfiguration {
+  val wiremockPort = 11111
+  val wiremockHost = "localhost"
+}
+
+trait WiremockHelper {
+
+  import WiremockConfiguration._
+
+  val wmConfig = wireMockConfig().port(wiremockPort)
+  val wireMockServer = new WireMockServer(wmConfig)
+
+  def startWiremock() = {
+    wireMockServer.start()
+    WireMock.configureFor(wiremockHost, wiremockPort)
+  }
+
+  def stopWiremock() = wireMockServer.stop()
+
+  def resetWiremock() = WireMock.reset()
+}

--- a/it/uk/gov/hmrc/support/wiremock/WiremockSpecSupport.scala
+++ b/it/uk/gov/hmrc/support/wiremock/WiremockSpecSupport.scala
@@ -1,0 +1,23 @@
+package uk.gov.hmrc.support.wiremock
+
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
+
+trait WiremockSpecSupport extends BeforeAndAfterEach with BeforeAndAfterAll with WiremockHelper {
+
+  suite: Suite =>
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    resetWiremock()
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    startWiremock()
+  }
+
+  override def afterAll(): Unit = {
+    stopWiremock()
+    super.afterAll()
+  }
+}

--- a/it/uk/gov/hmrc/support/wiremock/WiremockedServiceSupport.scala
+++ b/it/uk/gov/hmrc/support/wiremock/WiremockedServiceSupport.scala
@@ -1,0 +1,22 @@
+package uk.gov.hmrc.support.wiremock
+
+import uk.gov.hmrc.support.wiremock.WiremockConfiguration._
+
+trait WiremockedServiceSupport {
+
+  val wiremockedServices = List[String]()
+
+  lazy val wiremockedServicesConfiguration: Map[String, Any] = {
+    val servicesConfig = wiremockedServices.foldLeft(Map.empty[String, Any]) { (result, service) =>
+      result ++ Map(
+        s"microservice.services.$service.host" -> wiremockHost,
+        s"microservice.services.$service.port" -> wiremockPort
+      )
+    }
+    val auditingConfig= Map[String, Any](
+      "auditing.enabled" -> "false"
+    )
+
+    servicesConfig ++ auditingConfig
+  }
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -20,6 +20,7 @@ private object AppDependencies {
     "org.scalamock" %% "scalamock" % "4.0.0" % "test",
     "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.1" % "it",
     "uk.gov.hmrc" %% "hmrctest" % "3.0.0" % scope,
-    "uk.gov.hmrc" %% "reactivemongo-test" % "3.0.0" % "test"
+    "uk.gov.hmrc" %% "reactivemongo-test" % "3.0.0" % "test",
+    "com.github.tomakehurst" % "wiremock" % "2.12.0" % "it"
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,5 +9,3 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.9.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.0.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-service-manager" % "0.2.0")

--- a/test/uk/gov/hmrc/personaldetailsvalidation/matching/MatchingConnectorSpec.scala
+++ b/test/uk/gov/hmrc/personaldetailsvalidation/matching/MatchingConnectorSpec.scala
@@ -65,7 +65,7 @@ class MatchingConnectorSpec
           await(connector.doMatch(personalDetails))
         }
         exception.message shouldBe s"Unexpected response from POST http://host/authenticator/match with status: '$unexpectedStatus' and body: some response body"
-        exception.responseCode shouldBe unexpectedStatus
+        exception.responseCode shouldBe BAD_GATEWAY
       }
     }
   }


### PR DESCRIPTION
In ci-open, we don't have smserver. Because of this we should use wiremock for external dependencies in integration tests.